### PR TITLE
Add --forever to Slack notifications documentation

### DIFF
--- a/docs/slack-notifications.md
+++ b/docs/slack-notifications.md
@@ -26,6 +26,7 @@ Together, the command you run should look something like this...
 
 ```sh
 pokevision watch \
+  --forever \
   --lat=40.712774 \
   --lon=-74.013408 \
   --name="World Trade Center" \


### PR DESCRIPTION
The Slack notifications documentation should mention the `--forever` flag, otherwise the integration will seem to fail shortly after installation.
