### PR TITLE
A quick fix for possibly nil pokemon values

### DIFF
--- a/fetch_pokemon.go
+++ b/fetch_pokemon.go
@@ -1,33 +1,42 @@
 package main
 
 import (
-    "fmt"
-    "time"
+	"fmt"
+	"time"
 )
 
 const (
-    GET_MAP_DATA_URL = "https://pokevision.com/map/data/%v/%v"
+	GET_MAP_DATA_URL = "https://pokevision.com/map/data/%v/%v"
 )
 
 func FetchPokemonsInRegion(lat, lon float64) ([]Pokemon, error) {
-    data, err := RequestAPI(fmt.Sprintf(GET_MAP_DATA_URL, lat, lon))
-    if err != nil {
-        return nil, err
-    }
-    rawPokemons := data["pokemon"].([]interface{})
-    pokemons := make([]Pokemon, len(rawPokemons))
-    for index, unusableRawPokemon := range rawPokemons {
-        rawPokemon := unusableRawPokemon.(map[string]interface{})
-        pokemonId := int(rawPokemon["pokemonId"].(float64))
-        pokemons[index] = Pokemon{
-            ID: int(rawPokemon["id"].(float64)),
-            UID: rawPokemon["uid"].(string),
-            ExpiresAt: time.Unix(int64(rawPokemon["expiration_time"].(float64)), 0),
-            PokedexID: pokemonId,
-            Latitude: rawPokemon["latitude"].(float64),
-            Longitude: rawPokemon["longitude"].(float64),
-            IsAlive: rawPokemon["is_alive"].(bool),
-        }
-    }
-    return pokemons, nil
+	data, err := RequestAPI(fmt.Sprintf(GET_MAP_DATA_URL, lat, lon))
+	if err != nil {
+		return nil, err
+	}
+	rawPokemons := data["pokemon"].([]interface{})
+	pokemons := make([]Pokemon, len(rawPokemons))
+	for index, unusableRawPokemon := range rawPokemons {
+		rawPokemon := unusableRawPokemon.(map[string]interface{})
+		pokemonId := int(rawPokemon["pokemonId"].(float64))
+		uid, ok := rawPokemon["uid"].(string)
+		if !ok {
+			uid = ""
+		}
+		alive, ok := rawPokemon["is_alive"].(bool)
+		if !ok {
+			alive = false
+		}
+
+		pokemons[index] = Pokemon{
+			ID:        int(rawPokemon["id"].(float64)),
+			UID:       uid,
+			ExpiresAt: time.Unix(int64(rawPokemon["expiration_time"].(float64)), 0),
+			PokedexID: pokemonId,
+			Latitude:  rawPokemon["latitude"].(float64),
+			Longitude: rawPokemon["longitude"].(float64),
+			IsAlive:   alive,
+		}
+	}
+	return pokemons, nil
 }


### PR DESCRIPTION
This is a quick fix for #14.

A proper fix would require breaking out all API calls to use proper structs instead of throwing `map[string]interface{}` around, but I didn't want to change too much. If you need any help or advice refactoring things for type safety, please let me know.
