### PR TITLE
Log errors when using --forever

### DIFF
--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -106,6 +106,7 @@ func WatchAction(c *cli.Context) error {
 
 	handleError := func(err error) {
 		if config.Forever {
+			log.Println(err)
 			time.Sleep(time.Second * time.Duration(5))
 		} else {
 			bugsnag.Notify(err)


### PR DESCRIPTION
When using --forever there'll be no errors logged.
